### PR TITLE
Simple pagination using 'jekyll-paginate'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-paginate
-paginate: 5
+paginate: 10
 paginate_path: "/blog/page:num/"
 
 # Exclude from processing.

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-paginate
+paginate: 5
+paginate_path: "/blog/page:num/"
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_includes/paginated_post.html
+++ b/_includes/paginated_post.html
@@ -1,0 +1,10 @@
+{%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+<span class="post-meta">{{ include.post.date | date: date_format }}</span>
+<h3>
+    <a class="post-link" href="{{ include.post.url | relative_url }}">
+        {{ include.post.title | escape }}
+    </a>
+</h3>
+{%- if site.show_excerpts -%}
+{{ include.post.excerpt }}
+{%- endif -%}

--- a/_layouts/paginated.html
+++ b/_layouts/paginated.html
@@ -23,13 +23,7 @@ layout: default
 
     <!-- This loops through the paginated posts -->
     {% for post in paginator.posts %}
-    <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
-    <p class="author">
-        <span class="date">{{ post.date }}</span>
-    </p>
-    <div class="content">
-        {{ post.content }}
-    </div>
+    {% include paginated_post.html post=post %}
     {% endfor %}
 
     <!-- Pagination links with all pages -->

--- a/_layouts/paginated.html
+++ b/_layouts/paginated.html
@@ -1,0 +1,63 @@
+---
+layout: default
+---
+<div class="home">
+    {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+    {%- endif -%}
+
+    <!-- Pagination links -->
+    <div class="pagination">
+        {% if paginator.previous_page %}
+        <a href="{{ paginator.previous_page_path }}" class="previous">Previous</a>
+        {% else %}
+        <span class="previous">Previous</span>
+        {% endif %}
+        <span class="page_number ">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
+        {% if paginator.next_page %}
+        <a href="{{ paginator.next_page_path }}" class="next">Next</a>
+        {% else %}
+        <span class="next ">Next</span>
+        {% endif %}
+    </div>
+
+    <!-- This loops through the paginated posts -->
+    {% for post in paginator.posts %}
+    <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+    <p class="author">
+        <span class="date">{{ post.date }}</span>
+    </p>
+    <div class="content">
+        {{ post.content }}
+    </div>
+    {% endfor %}
+
+    <!-- Pagination links with all pages -->
+    {% if paginator.total_pages > 1 %}
+    <div class="pagination">
+        {% if paginator.previous_page %}
+        <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Prev</a>
+        {% else %}
+        <span>&laquo; Prev</span>
+        {% endif %}
+
+        {% for page in (1..paginator.total_pages) %}
+        {% if page == paginator.page %}
+        <em>{{ page }}</em>
+        {% elsif page == 1 %}
+        <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+        {% else %}
+        <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page
+            }}</a>
+        {% endif %}
+        {% endfor %}
+
+        {% if paginator.next_page %}
+        <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next &raquo;</a>
+        {% else %}
+        <span>Next &raquo;</span>
+        {% endif %}
+    </div>
+    {% endif %}
+
+</div>

--- a/_layouts/paginated.html
+++ b/_layouts/paginated.html
@@ -6,21 +6,6 @@ layout: default
     <h1 class="page-heading">{{ page.title }}</h1>
     {%- endif -%}
 
-    <!-- Pagination links -->
-    <div class="pagination">
-        {% if paginator.previous_page %}
-        <a href="{{ paginator.previous_page_path }}" class="previous">Previous</a>
-        {% else %}
-        <span class="previous">Previous</span>
-        {% endif %}
-        <span class="page_number ">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
-        {% if paginator.next_page %}
-        <a href="{{ paginator.next_page_path }}" class="next">Next</a>
-        {% else %}
-        <span class="next ">Next</span>
-        {% endif %}
-    </div>
-
     <!-- This loops through the paginated posts -->
     {% for post in paginator.posts %}
     {% include paginated_post.html post=post %}

--- a/index.html
+++ b/index.html
@@ -2,5 +2,5 @@
 # You don't need to edit this file, it's empty on purpose.
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-layout: home
+layout: paginated
 ---


### PR DESCRIPTION
- Create a dedicated layout for pagination, but may replace `home` layout
- Cannot use jekyll-paginate-v2 : so i used jekyll-paginate

> **[jekyll-paginate-v2](https://github.com/sverrirs/jekyll-paginate-v2)**
> Please note that this plugin is currently NOT supported by GitHub pages. Here is a list of all plugins supported. There is work underway to try to get it added it but until then please follow this GitHub guide to enable it or use Travis CI.