### PR TITLE
Pagination.v1.fix pagination links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "cyrblog.github.io" # the subpath of your site, e.g. /blog
+baseurl: "/cyrblog.github.io" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll

--- a/_layouts/paginated.html
+++ b/_layouts/paginated.html
@@ -24,7 +24,7 @@ layout: default
         {% if page == paginator.page %}
         <em>{{ page }}</em>
         {% elsif page == 1 %}
-        <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+        <a href="{{ '/' | relative_url }}">{{ page }}</a>
         {% else %}
         <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page
             }}</a>


### PR DESCRIPTION
Correct #3

Correction du bug sur la pagination : 
- [x] Correction de la `baseurl` : une `baseurl` relative est rajoutée en double dans le navigateur lors de l'utilisation de la pagination.
    **Solution :** la rendre absolue.
- [x] Correction de l'accès à la première page : la première page était en fait la "previous page"
    **Solution :** Recopie du code permettant d'accéder à l'acceuil dans `/jekyll/minima/_includes/header.html`